### PR TITLE
Sqrt Vector length scale for LeNet

### DIFF
--- a/LeNet.html
+++ b/LeNet.html
@@ -122,6 +122,18 @@
                                 <input type="checkbox" id="showLabels" name="showLabels" value="showLabels" checked>
                                 <label for="showLabels">Show Layer Labels</label>
                             </div>
+                            
+                            <hr>
+                            <div></div>
+                                <input type="checkbox" id="sqrtLength" name="sqrtLength" value="sqrtLength">
+                                <label for="sqrtLength">Sqrt Vector Length Scaling</label>
+                            </div>
+                            <div>
+                                <label for="lengthScale">Length Size Scaling</label>
+                                <input type="range" id="lengthScale" name="" min="1" max="200" step="1" value="100" style="position: relative; top: 3px;">
+                                <span id="lengthSpan">100</span>
+                                <span>%</span>
+                            </div>
 
                             <hr>
                             <h4>Architecture:</h4>
@@ -204,7 +216,7 @@
                                 </div>
 
                             </div>
-
+                            
                             <hr>
                             <div id="architecture2">
                                 <p>Vector Length</p>
@@ -264,8 +276,12 @@ function restart() {
     betweenLayers = $('#architecture').find('input[type="range"]').map((i,el) => $(el).val()).get().filter(input => $.isNumeric(input)).map(s => parseInt(s)); betweenLayers.pop();
 
     architecture2 = $('#architecture2').find('input').map((i,el) => $(el).val()).get().filter(input => $.isNumeric(input)).map(s => parseInt(s));
+    
+    sqrtLength = $('#sqrtLength').prop('checked');
+    lengthScale = parseFloat($('#lengthScale').prop('value'));
 
-    lenet.redraw({'architecture_':architecture, 'architecture2_':architecture2});
+
+    lenet.redraw({'architecture_':architecture, 'architecture2_':architecture2, 'sqrtLength_': sqrtLength, 'lengthScale_': lengthScale});
     lenet.redistribute({'betweenLayers_':betweenLayers});
 
 }
@@ -360,6 +376,18 @@ $(document).on('change', 'input[type="number"]', function(e) {
 $(document).on('change', 'input[type="text"]', function(e) {
     e.preventDefault();
 
+    restart();
+});
+
+$(document).on('change', '#sqrtLength', function(e) {
+    e.preventDefault();
+
+    restart();
+});
+
+$(document).on('change', '#lengthScale', function(e) {
+    e.preventDefault();
+    $("#lengthSpan").text(e.target.value)
     restart();
 });
 

--- a/LeNet.js
+++ b/LeNet.js
@@ -22,10 +22,16 @@ function LeNet() {
     var betweenLayersDefault = 12;
 
     var architecture = [];
+    var architecture2 = [];
     var lenet = {};
     var layer_offsets = [];
     var largest_layer_width = 0;
     var showLabels = true;
+
+    var sqrtLength = false;
+    var lengthScale = 100;
+    
+    let lengthFn = (length) => sqrtLength ? (Math.sqrt(length) * lengthScale/10) : (length * lengthScale/100);
 
     let textFn = (layer) => (typeof(layer) === "object" ? layer['numberOfSquares']+'@'+layer['squareHeight']+'x'+layer['squareWidth'] : "1x"+layer)
 
@@ -36,10 +42,14 @@ function LeNet() {
     /////////////////////////////////////////////////////////////////////////////
 
     function redraw({architecture_=architecture,
-                     architecture2_=architecture2}={}) {
+                     architecture2_=architecture2, 
+                     sqrtLength_=sqrtLength,
+                     lengthScale_=lengthScale,}={}) {
 
         architecture = architecture_;
         architecture2 = architecture2_;
+        sqrtLength = sqrtLength_;
+        lengthScale = lengthScale_;
 
         lenet.rects = architecture.map((layer, layer_index) => range(layer['numberOfSquares']).map(rect_index => {return {'id':layer_index+'_'+rect_index,'layer':layer_index,'rect_index':rect_index,'width':layer['squareWidth'],'height':layer['squareHeight']}}));
         lenet.rects = flatten(lenet.rects);
@@ -50,7 +60,7 @@ function LeNet() {
         lenet.conv_links = lenet.convs.map(conv => {return [Object.assign({'id':'link_'+conv['layer']+'_0','i':0},conv), Object.assign({'id':'link_'+conv['layer']+'_1','i':1},conv)]});
         lenet.conv_links = flatten(lenet.conv_links);
 
-        lenet.fc_layers = architecture2.map((size, fc_layer_index) => {return {'id': 'fc_'+fc_layer_index, 'layer':fc_layer_index+architecture.length, 'size':size/Math.sqrt(2)}});
+        lenet.fc_layers = architecture2.map((size, fc_layer_index) => {return {'id': 'fc_'+fc_layer_index, 'layer':fc_layer_index+architecture.length, 'size': lengthFn(size)}});
         lenet.fc_links = lenet.fc_layers.map(fc => { return [Object.assign({'id':'link_'+fc['layer']+'_0','i':0,'prevSize':10},fc), Object.assign({'id':'link_'+fc['layer']+'_1','i':1,'prevSize':10},fc)]});
         lenet.fc_links = flatten(lenet.fc_links);
 


### PR DESCRIPTION
### Implemented Feature request: Scaling for vectors in LeNet #39
Implemented the requested feature by adding a checkbox and a slide bar to enable square root (sqrt) and linear scaling for vector lengths in the LeNet style schematics.
The sqrt scaling feature is off by default to maintain current behavior unless specifically enabled.
All naming conventions are adapted from AlexNet.js and AlexNet.html, and the implementation is pretty much similar to log scaling feature there.

#### Showcase
![image](https://github.com/user-attachments/assets/756a20a0-7e99-4d51-bb39-1affca43027b)
Example for `1x2048` vector length, demonstrating the enhanced visualization as per the issue example.

#### Note
Initially, I experimented with log scaling, but it wasn't suitable for fully connected layers. The sqrt scaling option provides a more appropriate and visually balanced solution.