### PR TITLE
Add Input Image Support for First Layer

### DIFF
--- a/AlexNet.html
+++ b/AlexNet.html
@@ -131,6 +131,18 @@
                             </div>
                             
                             <div>
+                                <label for="inputImage">Upload Image for First Layer</label>
+                                <input type="file" id="inputImage" accept="image/*" class="form-control-file">
+                                <button id="removeImage" class="btn btn-secondary" style="display:none; margin-top: 5px; padding: 3px;">
+                                    Remove Image
+                                </button>
+                            </div>
+                            <div id="opacityControl" style="display:none;">
+                                <label for="imageOpacity">Image Opacity</label>
+                                <input type="range" id="imageOpacity" min="0" max="1" step="0.01" value="0.5" 
+                                    style="position: relative; top: 3px;">
+                            </div>
+                            <div>
                                 <label for="rectOpacity">Tensor Opacity</label>
                                 <input type="range" id="rectOpacity" name="" min="0" max="1" step="0.01" value="0.4" style="position: relative; top: 3px;">
                             </div>
@@ -370,8 +382,11 @@ $("#color1").change(        function () { alexnet.style({'color1_': this.value})
 $("#color2").change(        function () { alexnet.style({'color2_': this.value}); });
 $("#color3").change(        function () { alexnet.style({'color3_': this.value}); });
 $("#fontScale").change(        function () { alexnet.style({'fontScale_': this.value}); });
+$("#imageOpacity").change(function () { alexnet.style({ 'imageOpacity_': parseFloat(this.value) }); $(this).blur(); });
 $("#rectOpacity").change(   function () { alexnet.style({'rectOpacity_': parseFloat(this.value)}); $(this).blur(); });
 $("#filterOpacity").change( function () { alexnet.style({'filterOpacity_': parseFloat(this.value)}); $(this).blur(); });
+$("#inputImage").change(function(){var file=this.files[0];$('#imageOpacity').closest('div').toggle(!!file);$("#removeImage").toggle(!!file);if(file){alexnet.redraw({'inputimage_':URL.createObjectURL(file)});}$(this).blur();});
+$("#removeImage").click(function () { $("#inputImage").val(""); $("#imageOpacity").closest('div').hide();  $(this).hide();  alexnet.redraw({ 'inputimage_': null }); });
 $("#betweenLayers").change( function () { alexnet.redraw({'betweenLayers_': parseFloat(this.value)}); $(this).blur(); });
 $("#logDepth").change(      function () { alexnet.redraw({'logDepth_': this.checked}); });
 $("#depthScale").change(    function () { alexnet.redraw({'depthScale_': parseFloat(this.value)}); $(this).blur(); $("#depthSpan").text(this.value); });

--- a/AlexNet.html
+++ b/AlexNet.html
@@ -162,6 +162,10 @@
                                     <input type="range" id="imageOpacity" min="0" max="1" step="0.01" value="0.5" 
                                         style="position: relative; top: 3px;">
                                 </div>
+                                <div id="flipControl" style="display:none;">
+                                    <input type="checkbox" id="imageFlip" name="imageFlip" value="imageFlip">
+                                    <label for="imageFlip">Flip Image Horizontally</label>
+                                </div>
                             </div>
 
                             <hr>
@@ -388,11 +392,12 @@ $("#color1").change(        function () { alexnet.style({'color1_': this.value})
 $("#color2").change(        function () { alexnet.style({'color2_': this.value}); });
 $("#color3").change(        function () { alexnet.style({'color3_': this.value}); });
 $("#fontScale").change(        function () { alexnet.style({'fontScale_': this.value}); });
-$("#imageOpacity").change(function () { alexnet.style({ 'imageOpacity_': parseFloat(this.value) }); $(this).blur(); });
 $("#rectOpacity").change(   function () { alexnet.style({'rectOpacity_': parseFloat(this.value)}); $(this).blur(); });
 $("#filterOpacity").change( function () { alexnet.style({'filterOpacity_': parseFloat(this.value)}); $(this).blur(); });
-$("#inputImage").change(function(){var file=this.files[0];$('#imageOpacity').closest('div').toggle(!!file);$("#removeImage").toggle(!!file);if(file){alexnet.redraw({'inputimage_':URL.createObjectURL(file)});}$(this).blur();});
+$("#inputImage").change(function(){var file=this.files[0];$('#imageOpacity').closest('div').toggle(!!file);$('#flipControl').toggle(!!file);$("#removeImage").toggle(!!file);if(file){alexnet.redraw({'inputimage_':URL.createObjectURL(file)});}$(this).blur();});
 $("#removeImage").click(function () { $("#inputImage").val(""); $("#imageOpacity").closest('div').hide();  $(this).hide();  alexnet.redraw({ 'inputimage_': null }); });
+$("#imageOpacity").change(function () { alexnet.style({ 'imageOpacity_': parseFloat(this.value) }); $(this).blur(); });
+$("#imageFlip").change(function () { alexnet.style({'imageFlip_': this.checked}); });
 $("#betweenLayers").change( function () { alexnet.redraw({'betweenLayers_': parseFloat(this.value)}); $(this).blur(); });
 $("#logDepth").change(      function () { alexnet.redraw({'logDepth_': this.checked}); });
 $("#depthScale").change(    function () { alexnet.redraw({'depthScale_': parseFloat(this.value)}); $(this).blur(); $("#depthSpan").text(this.value); });

--- a/AlexNet.html
+++ b/AlexNet.html
@@ -131,18 +131,6 @@
                             </div>
                             
                             <div>
-                                <label for="inputImage">Upload Image for First Layer</label>
-                                <input type="file" id="inputImage" accept="image/*" class="form-control-file">
-                                <button id="removeImage" class="btn btn-secondary" style="display:none; margin-top: 5px; padding: 3px;">
-                                    Remove Image
-                                </button>
-                            </div>
-                            <div id="opacityControl" style="display:none;">
-                                <label for="imageOpacity">Image Opacity</label>
-                                <input type="range" id="imageOpacity" min="0" max="1" step="0.01" value="0.5" 
-                                    style="position: relative; top: 3px;">
-                            </div>
-                            <div>
                                 <label for="rectOpacity">Tensor Opacity</label>
                                 <input type="range" id="rectOpacity" name="" min="0" max="1" step="0.01" value="0.4" style="position: relative; top: 3px;">
                             </div>
@@ -158,6 +146,22 @@
                             <div>
                                 <label for="betweenLayers">Spacing Between Layers</label>
                                 <input type="range" id="betweenLayers" name="" min="10" max="100" step="1" value="20" style="position: relative; top: 3px;">
+                            </div>
+
+                            <div id="inputImageControl">
+                                <hr>
+                                <div>
+                                    <label for="inputImage">Upload Image for First Layer</label>
+                                    <input type="file" id="inputImage" accept="image/*" class="form-control-file">
+                                    <button id="removeImage" class="btn btn-secondary" style="display:none; margin-top: 5px; padding: 3px;">
+                                        Remove Image
+                                    </button>
+                                </div>
+                                <div id="opacityControl" style="display:none;">
+                                    <label for="imageOpacity">Image Opacity</label>
+                                    <input type="range" id="imageOpacity" min="0" max="1" step="0.01" value="0.5" 
+                                        style="position: relative; top: 3px;">
+                                </div>
                             </div>
 
                             <hr>
@@ -370,9 +374,11 @@ $('#rendererType input:radio').change(function() {
     rendererType = this.value;
     if (rendererType == 'svg') {
         $("#download").removeClass('disabled');
+        $("#inputImageControl").hide();
     }
     else if (rendererType == 'webgl') {
         $("#download").addClass('disabled');
+        $("#inputImageControl").show();
     }
     $(this).blur();
     alexnet.restartRenderer({'rendererType_':rendererType});

--- a/AlexNet.js
+++ b/AlexNet.js
@@ -148,11 +148,8 @@ function AlexNet() {
                         texture.wrapS = THREE.ClampToEdgeWrapping;
                         texture.wrapT = THREE.ClampToEdgeWrapping;
                         if (imageFlip) {
-                            texture.wrapS = THREE.RepeatWrapping;
-                            texture.repeat.x = -1;
-                        } else {
-                            texture.wrapS = THREE.ClampToEdgeWrapping;
-                            texture.repeat.x = 1;
+                            texture.matrix.setUvTransform(0, 0, -1, 1, 0, 0.5, 0);
+                            texture.matrixAutoUpdate = false;
                         }
                         image_material.map = texture;
                         var materials = [

--- a/AlexNet.js
+++ b/AlexNet.js
@@ -352,7 +352,7 @@ function AlexNet() {
     function style({color1_=color1,
                     color2_=color2,
                     color3_=color3,
-                    imageOpacity_ = imageOpacity_,
+                    imageOpacity_ = imageOpacity,
                     rectOpacity_=rectOpacity,
                     filterOpacity_=filterOpacity,
                     fontScale_ =fontScale,

--- a/AlexNet.js
+++ b/AlexNet.js
@@ -12,9 +12,10 @@ function AlexNet() {
     var color2 = '#99ddff';
     var color3 = '#ffbbbb';
 
-    var imageOpacity = 0.5; 
     var rectOpacity = 0.4;
     var filterOpacity = 0.4;
+    var imageOpacity = 0.5; 
+    var imageFlip = false;
     var fontScale = 1;
 
     var line_material = new THREE.LineBasicMaterial( { 'color':0x000000 } );
@@ -146,6 +147,13 @@ function AlexNet() {
                         texture.magFilter = THREE.LinearFilter;
                         texture.wrapS = THREE.ClampToEdgeWrapping;
                         texture.wrapT = THREE.ClampToEdgeWrapping;
+                        if (imageFlip) {
+                            texture.wrapS = THREE.RepeatWrapping;
+                            texture.repeat.x = -1;
+                        } else {
+                            texture.wrapS = THREE.ClampToEdgeWrapping;
+                            texture.repeat.x = 1;
+                        }
                         image_material.map = texture;
                         var materials = [
                             box_material,   
@@ -352,9 +360,10 @@ function AlexNet() {
     function style({color1_=color1,
                     color2_=color2,
                     color3_=color3,
-                    imageOpacity_ = imageOpacity,
                     rectOpacity_=rectOpacity,
                     filterOpacity_=filterOpacity,
+                    imageOpacity_ = imageOpacity,
+                    imageFlip_=imageFlip,
                     fontScale_ =fontScale,
                 }={}) {
         color1        = color1_;
@@ -363,8 +372,9 @@ function AlexNet() {
         
         rectOpacity   = rectOpacity_;
         filterOpacity = filterOpacity_;
-        fontScale = fontScale_;
         imageOpacity = imageOpacity_;
+        imageFlip     = imageFlip_;
+        fontScale = fontScale_;
         box_material.color = new THREE.Color(color1);
         conv_material.color = new THREE.Color(color2);
         pyra_material.color = new THREE.Color(color3);

--- a/AlexNet.js
+++ b/AlexNet.js
@@ -137,7 +137,7 @@ function AlexNet() {
 
             // Layer
             layer_geometry = new THREE.BoxGeometry( wf(layer), hf(layer), depthFn(layer['depth']) );
-            if (index === 0 && inputImage) {
+            if (index === 0 && inputImage && rendererType === 'webgl') {
                     var textureLoader = new THREE.TextureLoader();
                     const layer_geometry_cache = layer_geometry.clone();
                     const layer_offset_cache = layer_offsets[index];


### PR DESCRIPTION
# Pull Request: Add Input Image Support for First Layer

## Summary

This PR introduces support for displaying a user-selected image as the texture of the first layer in the AlexNet visualization. Users can now upload an image, adjust its opacity, and remove it at any time.

## Changes

### HTML (`AlexNet.html`)
- **Added file input control**: New `#inputImage` element allows users to select and upload images
- **Added image removal functionality**: "Remove Image" button for clearing the uploaded image
- **Added opacity control**: Opacity slider (`#imageOpacity`) that dynamically appears when an image is loaded

### JavaScript (`AlexNet.js`)
- **Enhanced `redraw()` function**: 
  - Extended to accept an `inputimage_` parameter
  - Implements conditional rendering logic for the first layer (index === 0)
  - Integrates `THREE.TextureLoader` to load and apply user images to the back face of the first layer box
- **Updated `style()` function**: 
  - Exposed `imageOpacity` setting for opacity adjustments

## UI Behavior

### Dynamic Interface Elements
- **Conditional visibility**: Opacity slider and remove button are shown/hidden based on image load state
- **Image lifecycle management**: Proper cleanup and re-rendering triggered on image removal

### User Workflow
1. User uploads an image via the file input
2. Image appears as texture on the first AlexNet layer (back face of the first cuboid to be precise)
3. User can adjust opacity using the slider (0-100%)
4. User can remove the image using the "Remove Image" button
5. Opacity Control elements hide automatically when no image is loaded

## Images

![Neural Network Image](https://i.sstatic.net/20t0HyM6.png)

![Sidebar Image](https://i.sstatic.net/XIvjdASc.png)

## **Note**: 
The input image will not be displayed in the SVG renderer as it does not support `THREE.js` texture.

## Further Improvements:
- I am not sure to which face the image should be applied. Currently, it is applied to the back face of the first layer's cuboid. I tried applying it to the front face, but it hid the convolution filter so I removed it. Something has to be done to side faces too as they look a bit weird when viewed from sideways. I thought of showing 3 slices R,G,B but then we can change the number of channels in the first layer, so I left it as is. I also thought of taking some gaussian blur of the image and applying it to the side faces, but I have not implemented that for the sake of simplicity. If you have any suggestions, please let me know.

- I had problems using texture to render the image on the first layer because of asynchronous loading of the image. I had to use a callback function to ensure that the image is loaded before rendering it. Maybe there is a better way to do it.

- The remove button UI can be made better but I refrained from using style excessively to keep the code simple and focused on functionality.
