### PR TITLE
Two Branches Support after Final Convolution Layer

### DIFF
--- a/AlexNet.html
+++ b/AlexNet.html
@@ -271,7 +271,7 @@
                             <div id="architecture2">
                                 <p>Vector Length</p>
                                 <div class="branch-1">
-                                <p>Branch 1</p>
+                                <p id="branch-1-label" style="display:none;">Branch 1</p>
                                 <div class="row entry">
                                     <div class="input-group mb-2 mr-sm-2 col-5">
                                         <button class="btn btn-secondary btn-remove input-group-prepend"><span class="fa fa-minus"></span></button>
@@ -297,7 +297,11 @@
                                     </div>
                                 </div>
                                 </div>
-                                <div class="branch-2">
+                                <div>
+                                    <input type="checkbox" id="addSecondBranch" name="addSecondBranch" value="addSecondBranch">
+                                    <label for="addSecondBranch">Do you want to add a second branch?</label>
+                                </div>
+                                <div class="branch-2" style="display:none;">
                                         <p>Branch 2</p>
                                         <div class="row entry">
                                             <div class="input-group mb-2 mr-sm-2 col-5">
@@ -459,6 +463,16 @@ $(document).on('click', '#architecture2 .btn-remove', function(e) {
 
     return false;
 
+});
+
+$("#addSecondBranch").change(function() {
+    if (this.checked) {
+        $("#branch-1-label").show();
+        $(".branch-2").show();
+    } else {
+        $("#branch-1-label").hide();
+        $(".branch-2").hide();
+    }
 });
 
 $(document).on('change', 'input', function(e) {

--- a/AlexNet.html
+++ b/AlexNet.html
@@ -270,6 +270,7 @@
                             <hr>
                             <div id="architecture2">
                                 <p>Vector Length</p>
+                                <div class="branch-1">
                                 <div class="row entry">
                                     <div class="input-group mb-2 mr-sm-2 col-5">
                                         <button class="btn btn-secondary btn-remove input-group-prepend"><span class="fa fa-minus"></span></button>
@@ -293,6 +294,18 @@
                                         <button class="btn btn-primary btn-add input-group-prepend"><span class="fa fa-plus"></span></button>
                                         <input type="number" class="form-control" name="vectorLength" step="1"/>
                                     </div>
+                                </div>
+                                </div>
+                                <div class="branch-2">
+                                        <p>Branch 2</p>
+                                        <div class="row entry">
+                                            <div class="input-group mb-2 mr-sm-2 col-5">
+                                                <button class="btn btn-primary btn-add input-group-prepend"><span
+                                                        class="fa fa-plus"></span></button>
+                                                <input type="number" class="form-control" name="vectorLength"
+                                                    step="1" />
+                                            </div>
+                                        </div>
                                 </div>
 
                             </div>
@@ -341,7 +354,10 @@ function restart() {
         ).get()
          .filter(layer => Object.values(layer).every(val => !_.isNaN(val)));
 
-    architecture2 = $('#architecture2').find('input').map((i,el) => $(el).val()).get().filter(input => $.isNumeric(input)).map(s => parseInt(s));
+    architecture2 = {
+                    branch1: $('.branch-1').find('input').map((i, el) => $(el).val()).get().filter(input => $.isNumeric(input)).map(s => parseInt(s)),
+                    branch2: $('.branch-2').find('input').map((i, el) => $(el).val()).get().filter(input => $.isNumeric(input)).map(s => parseInt(s))
+                };
 
     alexnet.redraw({'architecture_':architecture, 'architecture2_':architecture2});
 
@@ -419,7 +435,7 @@ $(document).on('click', '#architecture .btn-remove', function(e) {
 $(document).on('click', '#architecture2 .btn-add', function(e) {
     e.preventDefault();
 
-    var controlForm = $('#architecture2');
+    var controlForm = $(this).closest('.branch-1, .branch-2');
     var currentEntry = $(this).parents('.entry:first');
     var newEntry = $(currentEntry.clone()).appendTo(controlForm);
 

--- a/AlexNet.html
+++ b/AlexNet.html
@@ -271,6 +271,7 @@
                             <div id="architecture2">
                                 <p>Vector Length</p>
                                 <div class="branch-1">
+                                <p>Branch 1</p>
                                 <div class="row entry">
                                     <div class="input-group mb-2 mr-sm-2 col-5">
                                         <button class="btn btn-secondary btn-remove input-group-prepend"><span class="fa fa-minus"></span></button>

--- a/AlexNet.js
+++ b/AlexNet.js
@@ -22,7 +22,7 @@ function AlexNet() {
     var pyra_material = new THREE.MeshBasicMaterial( {'color':color3, 'side':THREE.DoubleSide, 'transparent':true, 'opacity':filterOpacity, 'depthWrite':false, 'needsUpdate':true} );
 
     var architecture = [];
-    var architecture2 = [];
+    var architecture2 = {branch1: [], branch2: []};
     var betweenLayers = 20;
 
     var logDepth = true;
@@ -126,7 +126,6 @@ function AlexNet() {
 
         z_offset = -(sum(architecture.map(layer => depthFn(layer['depth']))) + (betweenLayers * (architecture.length - 1))) / 3;
         layer_offsets = pairWise(architecture).reduce((offsets, layers) => offsets.concat([offsets.last() + depthFn(layers[0]['depth'])/2 + betweenLayers + depthFn(layers[1]['depth'])/2]), [z_offset]);
-        layer_offsets = layer_offsets.concat(architecture2.reduce((offsets, layer) => offsets.concat([offsets.last() + widthFn(2) + betweenLayers]), [layer_offsets.last() + depthFn(architecture.last()['depth'])/2 + betweenLayers + widthFn(2)]));
 
         architecture.forEach( function( layer, index ) {
 
@@ -201,26 +200,56 @@ function AlexNet() {
 
         });
 
-        architecture2.forEach( function( layer, index ) {
+        const lastArchitectureOffset = layer_offsets.last() + depthFn(architecture.last()['depth']) / 2 + betweenLayers;
+    
+        const branch1_offsets = architecture2.branch1.reduce((offsets, layer) => 
+            offsets.concat([offsets.last() + widthFn(2) + betweenLayers]), 
+            [lastArchitectureOffset + widthFn(2)]
+        );
+        
+        const branch2_offsets = architecture2.branch2.reduce((offsets, layer) => 
+            offsets.concat([offsets.last() + widthFn(2) + betweenLayers]), 
+            [lastArchitectureOffset + widthFn(2)]
+        );
+
+        const isBranch1Empty = architecture2.branch1.length === 0;
+        const isBranch2Empty = architecture2.branch2.length === 0;
+        const branch1XPos = isBranch2Empty ? 0 : -30;
+        const branch2XPos = isBranch1Empty ? 0 : 30;
+
+        architecture2.branch1.forEach( function( layer, index ) {
 
             // Dense
             layer_geometry = new THREE.BoxGeometry( widthFn(2), depthFn(layer), widthFn(2) );
             layer_object = new THREE.Mesh( layer_geometry, box_material );
-            layer_object.position.set(0, 0, layer_offsets[architecture.length + index]);
+            layer_object.position.set(branch1XPos, 0, branch1_offsets[index]);
             layers.add( layer_object );
 
             layer_edges_geometry = new THREE.EdgesGeometry( layer_geometry );
             layer_edges_object = new THREE.LineSegments( layer_edges_geometry, line_material );
-            layer_edges_object.position.set(0, 0, layer_offsets[architecture.length + index]);
+            layer_edges_object.position.set(branch1XPos, 0, branch1_offsets[index]);
             layers.add( layer_edges_object );
 
-            direction = new THREE.Vector3( 0, 0, 1 );
-            origin = new THREE.Vector3( 0, 0, layer_offsets[architecture.length + index] - betweenLayers - widthFn(2)/2 + 1 );
-            length = betweenLayers - 2;
-            headLength = betweenLayers/3;
-            headWidth = 5;
-            arrow = new THREE.ArrowHelper( direction, origin, length, 0x000000, headLength, headWidth );
-            pyramids.add( arrow );
+            if (index === 0 && !isBranch2Empty) {
+                const lastConvLayerIndex = architecture.length - 1;
+                const lastConvLayerZ = layer_offsets[lastConvLayerIndex] + depthFn(architecture[lastConvLayerIndex]['depth']) / 2;
+                const origin = new THREE.Vector3(-5, 0, betweenLayers/3 + lastConvLayerZ);
+                const target = new THREE.Vector3(branch1XPos, 0, branch1_offsets[index] - widthFn(2) / 2);
+                const direction = target.clone().sub(origin).normalize();
+                const length = betweenLayers;
+                const headLength = betweenLayers / 3;
+                const headWidth = 5;
+                const arrow = new THREE.ArrowHelper(direction, origin, length, 0x000000, headLength, headWidth);
+                pyramids.add(arrow);
+            } else {
+                direction = new THREE.Vector3(0, 0, 1);
+                origin = new THREE.Vector3(branch1XPos, 0, branch1_offsets[index] - betweenLayers - widthFn(2) / 2 + 1);
+                length = betweenLayers - 2;
+                headLength = betweenLayers / 3;
+                headWidth = 5;
+                arrow = new THREE.ArrowHelper(direction, origin, length, 0x000000, headLength, headWidth);
+                pyramids.add(arrow);
+            };
 
             if (showDims) {
 
@@ -230,6 +259,47 @@ function AlexNet() {
             }
 
 
+        });
+
+         architecture2.branch2.forEach(function (layer, index) {
+
+            // Dense
+            layer_geometry = new THREE.BoxGeometry(widthFn(2), depthFn(layer), widthFn(2));
+            layer_object = new THREE.Mesh(layer_geometry, box_material);
+            layer_object.position.set(branch2XPos, 0, branch2_offsets[index]);
+            layers.add(layer_object);
+
+            layer_edges_geometry = new THREE.EdgesGeometry(layer_geometry);
+            layer_edges_object = new THREE.LineSegments(layer_edges_geometry, line_material);
+            layer_edges_object.position.set(branch2XPos, 0, branch2_offsets[index]);
+            layers.add(layer_edges_object);
+
+            if (index === 0 && !isBranch1Empty) {
+                const lastConvLayerIndex = architecture.length - 1;
+                const lastConvLayerZ = layer_offsets[lastConvLayerIndex] + depthFn(architecture[lastConvLayerIndex]['depth']) / 2;
+                const origin = new THREE.Vector3(5, 0, betweenLayers/3 + lastConvLayerZ);
+                const target = new THREE.Vector3(branch2XPos, 0, branch2_offsets[index] - widthFn(2) / 2);
+                const direction = target.clone().sub(origin).normalize();
+                const length = betweenLayers;
+                const headLength = betweenLayers / 3;
+                const headWidth = 5;
+                const arrow = new THREE.ArrowHelper(direction, origin, length, 0x000000, headLength, headWidth);
+                pyramids.add(arrow);
+            } else {
+                direction = new THREE.Vector3(0, 0, 1);
+                origin = new THREE.Vector3(branch2XPos, 0, branch2_offsets[index] - betweenLayers - widthFn(2) / 2 + 1);
+                length = betweenLayers - 2;
+                headLength = betweenLayers / 3;
+                headWidth = 5;
+                arrow = new THREE.ArrowHelper(direction, origin, length, 0x000000, headLength, headWidth);
+                pyramids.add(arrow);
+            }
+
+            if (showDims) {
+
+                // Dims
+                sprite = makeTextSprite(rendererType === 'svg', layer.toString(), layer_object.position, new THREE.Vector3(3, depthFn(layer) / 2 + 4, 3));
+            }
         });
 
         scene.add( layers );


### PR DESCRIPTION
# Pull Request: Two Branches Support after Final Convolution Layer

## Summary

This pull request adds support for **dual branches** in the AlexNet visualization after the final convolutional layer. Users can now dynamically add, remove, and visualize two independent branches ("Branch 1" and "Branch 2"). This is useful for architectures with multi-task heads, auxiliary classifiers, or Siamese/parallel branches.
Some papers that use this architecture include:

- [Pose Estimation for Non-Cooperative Rendezvous Using Neural Networks](https://arxiv.org/abs/1906.09868)
- [Multi-Task Learning with Deep Neural Networks: A Survey](https://arxiv.org/abs/2009.09796)
- [Multi-task Learning For Joint Action and Gesture Recognition](https://arxiv.org/abs/2505.17867)

## Changes

### HTML (`AlexNet.html`)

- **Branch UI Additions:**
  - Added two sections within `#architecture2`:
    - `.branch-1` for Branch 1 layers
    - `.branch-2` for Branch 2 layers
  - Each branch has its own input group and add/remove buttons.
  - Clear labels for each branch.

### JavaScript (`AlexNet.js`)

- **Data Structure Update:**
  - Changed `architecture2` from an array to an object: `{ branch1: [], branch2: [] }`.
- **Layer Parsing:**
  - On redraw, each branch's layers are parsed independently from their respective inputs.
- **3D Visualization Logic:**
  - Each branch's layers are rendered as separate stacks, offset in the X-axis.
  - Arrows connect the last convolution layer to each branch.
  - Handles cases where only one or both branches are present.
- **UI Behavior:**
  - Add/remove buttons work independently for each branch.
  - Visualization updates live as the user edits layers.


## UI Behavior

### Dynamic Interface Elements

- **Add/Remove Layer:**
  - Each branch has its own "+" (add) and "−" (remove) buttons.
  - Layers can be added/removed dynamically in either branch.
- **Live Updates:**
  - Visualization updates in real-time as the user edits layer configurations.

### User Workflow

1. **Define Main Architecture:**  
   Add convolutional/dense layers to the main architecture as before.
2. **Add Branches:**  
   Add layers to either or both branches after the final convolution layer.
3. **Visualize:**  
   Visualization shows the main trunk and both branches, clearly separated and connected.


## Images

**Dual Branch Neural Network:**

![Neural Network Image](https://i.sstatic.net/fQl3BR6t.png)

**Sidebar:**

![Sidebar Image](https://i.sstatic.net/L8L7Xzdr.png)

## Notes:
- I ensure that the new branches do not interfere with the main architecture. So if branch 2 is empty, it will not affect the visualization of branch 1 and it is exactly like before.
- I don't know if it should be added to the main branch or not. I needed this feature for my own project, so I thought it would be useful to others as well. 

## Further Improvements

- I tried generalising the code to support more than two branches, but it became too complex and require significant logic for angle and distance calculations. Moreover more than 5 branches would be too complex to visualize clearly in my opinion. So if someone wants to add more branches, they can do so by duplicating the existing branch code and updating the logic accordingly.
- Better implementation. Currenly, the code is a bit repetitive for each branch. A more modular approach could be implemented to reduce redundancy and a better UI of the sidebar so that Branch 2 column is not visible on the outset.
- Allowing users to specify branch names.
- Convolutional layers in each branch.


