### PR TITLE
fix: correct width and height label placement in layer dimensions

### DIFF
--- a/AlexNet.js
+++ b/AlexNet.js
@@ -165,8 +165,8 @@ function AlexNet() {
                         layers.add(layer_object);
                         if (showDims) {
                             makeTextSprite(rendererType === 'svg', layer['depth'].toString(), layer_object.position, new THREE.Vector3(wf(layer) / 2 + 2, hf(layer) / 2 + 2, 0));
-                            makeTextSprite(rendererType === 'svg', layer['width'].toString(), layer_object.position, new THREE.Vector3(wf(layer) / 2 + 3, 0, depthFn(layer['depth']) / 2 + 3));
-                            makeTextSprite(rendererType === 'svg', layer['height'].toString(), layer_object.position, new THREE.Vector3(0, -hf(layer) / 2 - 3, depthFn(layer['depth']) / 2 + 3));
+                            makeTextSprite(rendererType === 'svg', layer['height'].toString(), layer_object.position, new THREE.Vector3(wf(layer) / 2 + 3, 0, depthFn(layer['depth']) / 2 + 3));
+                            makeTextSprite(rendererType === 'svg', layer['width'].toString(), layer_object.position, new THREE.Vector3(0, -hf(layer) / 2 - 3, depthFn(layer['depth']) / 2 + 3));
                         }
                     });
                 } else {
@@ -223,9 +223,9 @@ function AlexNet() {
                 // Dims
                 sprite = makeTextSprite(rendererType === 'svg', layer['depth'].toString(), layer_object.position, new THREE.Vector3( wf(layer)/2 + 2, hf(layer)/2 + 2, 0 ));
 
-                sprite = makeTextSprite(rendererType === 'svg', layer['width'].toString(), layer_object.position, new THREE.Vector3( wf(layer)/2 + 3, 0, depthFn(layer['depth'])/2 + 3 ));
+                sprite = makeTextSprite(rendererType === 'svg', layer['height'].toString(), layer_object.position, new THREE.Vector3( wf(layer)/2 + 3, 0, depthFn(layer['depth'])/2 + 3 ));
 
-                sprite = makeTextSprite(rendererType === 'svg', layer['height'].toString(), layer_object.position, new THREE.Vector3( 0, -hf(layer)/2 - 3, depthFn(layer['depth'])/2 + 3 ));
+                sprite = makeTextSprite(rendererType === 'svg', layer['width'].toString(), layer_object.position, new THREE.Vector3( 0, -hf(layer)/2 - 3, depthFn(layer['depth'])/2 + 3 ));
 
             }
 


### PR DESCRIPTION
This Pull Request will fix the correct width and height label placement in layer dimensions

before:

<img width="1691" height="548" alt="image" src="https://github.com/user-attachments/assets/259e50d0-d2b9-4b7a-90e0-ae921a8559bc" />


after:

<img width="1852" height="548" alt="image" src="https://github.com/user-attachments/assets/0a6cec07-e659-44a2-9f13-90caea8864e1" />

