### PR TITLE
fix: conv target feature map arrow in AlexNet

### DIFF
--- a/AlexNet.js
+++ b/AlexNet.js
@@ -198,14 +198,15 @@ function AlexNet() {
 
                 base_z = layer_offsets[index] + (depthFn(layer['depth']) / 2);
                 summit_z = layer_offsets[index] + (depthFn(layer['depth']) / 2) + betweenLayers;
-                next_layer_wh = widthFn(architecture[index+1]['width'])
+                next_layer_w = wf(architecture[index+1]);
+                next_layer_h = hf(architecture[index+1]);
 
                 pyramid_geometry.vertices = [
                     new THREE.Vector3( (layer['rel_x'] * wf(layer)) + (convFn(layer['filterWidth'])/2), (layer['rel_y'] * hf(layer)) + (convFn(layer['filterHeight'])/2), base_z ),  // base
                     new THREE.Vector3( (layer['rel_x'] * wf(layer)) + (convFn(layer['filterWidth'])/2), (layer['rel_y'] * hf(layer)) - (convFn(layer['filterHeight'])/2), base_z ),  // base
                     new THREE.Vector3( (layer['rel_x'] * wf(layer)) - (convFn(layer['filterWidth'])/2), (layer['rel_y'] * hf(layer)) - (convFn(layer['filterHeight'])/2), base_z ),  // base
                     new THREE.Vector3( (layer['rel_x'] * wf(layer)) - (convFn(layer['filterWidth'])/2), (layer['rel_y'] * hf(layer)) + (convFn(layer['filterHeight'])/2), base_z ),  // base
-                    new THREE.Vector3( (layer['rel_x'] * next_layer_wh),                           (layer['rel_y'] * next_layer_wh),                           summit_z)  // summit
+                    new THREE.Vector3( (layer['rel_x'] * next_layer_w),                            (layer['rel_y'] * next_layer_h),                            summit_z)  // summit
                 ];
                 pyramid_geometry.faces = [new THREE.Face3(0,1,2),new THREE.Face3(0,2,3),new THREE.Face3(1,0,4),new THREE.Face3(2,1,4),new THREE.Face3(3,2,4),new THREE.Face3(0,3,4)];
 


### PR DESCRIPTION
**Problem Description:**  
The pyramid connecting each conv layer to the next feature map has its summit vertex computed using only the next layer's width for both the X and Y coordinates for AlexNet Style:

```js
next_layer_wh = widthFn(architecture[index+1]['width'])
// summit:
new THREE.Vector3( rel_x * next_layer_wh, rel_y * next_layer_wh, summit_z )
```

For non-square feature maps i.e. Conv1D (width ≠ height), this causes the apex to point outside the target layer's bounds on the Y axis.

<img width="3106" height="1045" alt="image" src="https://github.com/user-attachments/assets/ab44631a-2258-4333-a7d0-c745ad9ab017" />


**Fix:**   
Split into two variables so X and Y use their respective dimensions:

```js
next_layer_w = wf(architecture[index+1])  // widthFn(width)
next_layer_h = hf(architecture[index+1])  // widthFn(height)
// summit:
new THREE.Vector3( rel_x * next_layer_w, rel_y * next_layer_h, summit_z )
```

<img width="2902" height="846" alt="image" src="https://github.com/user-attachments/assets/b57643ac-af63-4324-b5c2-08d6b70ec91d" />

This bug was discovered as a side effect of my prior commit that corrected swapped height/width labels when trying to visualize non-square layers i.e. Conv1D Layers


**No breaking changes:**  
Conv2D Layers still work with the updated calculation.

<img width="1786" height="851" alt="image" src="https://github.com/user-attachments/assets/fbe5e394-299d-4c93-8bda-08aa6bcad04b" />
